### PR TITLE
svelte-typescript-webpack-boilerplate was renamed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@
 - [single-spa-example](https://github.com/CanopyTax/single-spa-examples/tree/master/src/svelte)
 
 ## Starters
-- [svelte-typescript-webpack-boilerplate](https://github.com/brakmic/Svelte-TypeScript-WebPack-Boilerplate)
+- [svelte-typescript-webpack-starter](https://github.com/brakmic/Svelte-TypeScript-WebPack-Starter)
 
 ## Resources
 - [Guide](https://svelte.technology/guide)


### PR DESCRIPTION
svelte-typescript-webpack-boilerplate was renamed to svelte-typescript-webpack-starter

<!-- Please fill in the **bold** fields -->

**[Insert URL to the item here.]**
**[Explain what this item is about and why it should be included here.]**

<br>

By submitting this pull request, I promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.