### PR TITLE
Adding svelte-querystring-router

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,7 @@
 ### Routing
 - [abstract-state-router](https://github.com/TehShrike/abstract-state-router)
 - [svelte-router](https://github.com/jikkai/svelte-router)
+- [svelte-querystring-router](https://github.com/TehShrike/svelte-querystring-router)
 
 ### Miscellaneous
 - [svelte-extras](https://github.com/sveltejs/svelte-extras) - Extra methods for components


### PR DESCRIPTION
<!-- Please fill in the **bold** fields -->

**svelte-querystring-router**
**A very specific kind of router, only pays attention to the querystring.**

<br>

By submitting this pull request, I promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.