### PR TITLE
Adding svelte-brunch to Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -185,6 +185,7 @@
 - [meteor-svelte](https://github.com/meteor-svelte/meteor-svelte)
 - [svelte-ruby](https://github.com/bordeeinc/svelte-ruby) - Ruby Gem wrapper for the compiler
 - [svelte-rack](https://github.com/bordeeinc/svelte-rack) - Rack middleware to compile components to Javascript
+- [svelte-brunch](https://github.com/kazzkiq/svelte-brunch) - Svelte plugin for [Brunch](http://brunch.io/) build-tool
 
 ## Plugins
 ### Routing


### PR DESCRIPTION
**https://github.com/kazzkiq/svelte-brunch**

**`svelte-brunch` is a plugin for Brunch build-tool. It enables users to effortlessly plug-in Svelte to their Brunch projects.**